### PR TITLE
day is not a datetime object

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ public function indexAction()
         <tr>
             {% for day in week %}
                 <td>
-                    {% if month.contains(day) %}
+                    {% if month.contains(day.begin) %}
                         {{ day.begin.format('d') }}
                     {% else %}
                         &nbsp;


### PR DESCRIPTION
another documentation fix as the provided sample code does not work: day is being passed to contains, but contains requires a \DateTime object. passing day.begin fixes the problem
