### PR TITLE
Made compatible with Symfony 4.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vendor
 phpunit.xml
+composer.lock

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -18,8 +18,8 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $builder = new TreeBuilder();
-        $root = $builder->root('frequence_web_calend_r');
+        $builder = new TreeBuilder('frequence_web_calend_r');
+        $root = method_exists($builder, 'getRootNode') ? $builder->getRootNode() : $builder->root('frequence_web_calend_r');
 
         $root
             ->children()

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,7 +10,6 @@
         convertWarningsToExceptions = "true"
         processIsolation            = "false"
         stopOnFailure               = "false"
-        syntaxCheck                 = "false"
         bootstrap                   = "Tests/bootstrap.php" >
 
     <testsuites>


### PR DESCRIPTION
This is to make the Dependency Injection configuration tree builder compatible with Symfony 4.2, with backwards compatibility.